### PR TITLE
Unpin to use development version

### DIFF
--- a/travis.cfg
+++ b/travis.cfg
@@ -8,3 +8,6 @@ package-extras = [test]
 allow-hosts +=
     code.google.com
     robotframework.googlecode.com
+
+[versions]
+collective.z3cform.datetimewidget =


### PR DESCRIPTION
Fix for issue [#8] 

Because version of this package is pinned, but for our testing
environment we want to have latest develop version we override package
version to nothing.

http://grok.zope.org/documentation/how-to/trail-blazing#trail-blazing-working-with-unreleased-eggs