### PR TITLE
Prevent invalid data is silently accepted

### DIFF
--- a/src/collective/z3cform/datetimewidget/converter.py
+++ b/src/collective/z3cform/datetimewidget/converter.py
@@ -25,16 +25,21 @@ from z3c.form.converter import BaseDataConverter
 from collective.z3cform.datetimewidget.interfaces import DateValidationError, DatetimeValidationError
 
 class DateDataConverter(BaseDataConverter):
-    
+
     def toWidgetValue(self, value):
         if value is self.field.missing_value:
             return ('', '', '')
         return (value.year, value.month, value.day)
 
     def toFieldValue(self, value):
-        for val in value:
-            if not val:
-                return self.field.missing_value
+        if len(value) != 3:
+            raise DateValidationError
+
+        year, month, day = value
+
+        if not year \
+                and not day:
+            return self.field.missing_value
 
         try:
             value = map(int, value)
@@ -46,16 +51,21 @@ class DateDataConverter(BaseDataConverter):
             raise DateValidationError
 
 class DatetimeDataConverter(DateDataConverter):
-    
+
     def toWidgetValue(self, value):
         if value is self.field.missing_value:
             return ('', '', '', '00', '00')
         return (value.year, value.month, value.day, value.hour, value.minute)
 
     def toFieldValue(self, value):
-        for val in value:
-            if not val:
-                return self.field.missing_value
+        if len(value) != 5:
+            raise DatetimeValidationError
+
+        year, month, day, hour, minute = value
+
+        if not year \
+                and not day:
+            return self.field.missing_value
 
         try:
             value = map(int, value)

--- a/src/collective/z3cform/datetimewidget/converter.txt
+++ b/src/collective/z3cform/datetimewidget/converter.txt
@@ -37,10 +37,10 @@ We can also convert widget values to field values.
     >>> converter.toFieldValue(('2009', '5', '10'))
     datetime.date(2009, 5, 10)
 
-If any of the widget value components is missing, a value of None will be
+If day and year of the widget value components is missing, a value of None will be
 returned.
 
-    >>> converter.toFieldValue(('', '5', '10')) is None
+    >>> converter.toFieldValue(('', '5', '')) is None
     True
 
 If all of the widget value components are present but they don't correspond to
@@ -52,3 +52,42 @@ a valid date, a validation error will be raised.
     DateValidationError
 
 
+Let's set up a datetime field, datetime widget, and a converter adapting both of them.
+
+    >>> from zope.schema import Datetime
+    >>> from collective.z3cform.datetimewidget import DatetimeWidget
+    >>> from collective.z3cform.datetimewidget.converter import DatetimeDataConverter
+    >>> field = Datetime()
+    >>> request = TestRequest()
+    >>> widget = DatetimeWidget(request)
+    >>> converter = DatetimeDataConverter(field, widget)
+
+Now we can convert field values to widget values.
+
+    >>> from datetime import datetime
+    >>> converter.toWidgetValue(datetime(2009, 5, 10, 15, 35))
+    (2009, 5, 10, 15, 35)
+
+A value of None results in a tuple of empty strings.
+
+    >>> converter.toWidgetValue(None)
+    ('', '', '', '00', '00')
+
+We can also convert widget values to field values.
+
+    >>> converter.toFieldValue(('2009', '5', '10', '15', '35'))
+    datetime.datetime(2009, 5, 10, 15, 35)
+
+If day and year of the widget value components is missing, a value of None will be
+returned.
+
+    >>> converter.toFieldValue(('', '5', '', '00', '00')) is None
+    True
+
+If all of the widget value components are present but they don't correspond to
+a valid date, a validation error will be raised.
+
+    >>> converter.toFieldValue(('2009', '42', '42', '42', '82'))
+    Traceback (most recent call last):
+    ...
+    DatetimeValidationError


### PR DESCRIPTION
When user wants to set ``Date`` or ``Datetime`` value and missed one of
the fields (day, year, hour or minute) it silently sets it to None
without error messages which input is not valid.

Unfortunately we cannot check that there was missed one of the inputs by
validator because validator has value (``datetime``) which is already
converted.

I suggest that value will be set into None when user lefts empty fields
*day* and *year*.

I create this pull request mostly to discuss about this unexpected behavior.
